### PR TITLE
Add imports to example for clarity

### DIFF
--- a/docs/logger.md
+++ b/docs/logger.md
@@ -5,6 +5,9 @@ Logger logs the information about each HTTP request.
 ### Usage
 
 ```ts
+import { abc } from "https://deno.land/x/abc/mod.ts";
+import { logger } from "https://deno.land/x/abc/middleware/logger.ts";
+
 const app = abc();
 app.use(logger());
 ```


### PR DESCRIPTION
As it's not made clear elsewhere, including the import in the example should help to reduce confusion.

This project is an awesome concept overall, awesome work!

I was initially confused on where `logger` actually came from. The required change was simple enough to figure out and taught me a bit in terms of getting used to Deno's import pattern.