### PR TITLE
Fixed std versions - Fixes (#91)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: denolib/setup-deno@master
         with:
-          deno-version: 1.1.0
+          deno-version: 1.2.0
 
       - run: deno --version
       - run: deno fmt --check

--- a/vendor/https/deno.land/std/encoding/utf8.ts
+++ b/vendor/https/deno.land/std/encoding/utf8.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.59.0/encoding/utf8.ts";
+export * from "https://deno.land/std@0.61.0/encoding/utf8.ts";

--- a/vendor/https/deno.land/std/http/cookie.ts
+++ b/vendor/https/deno.land/std/http/cookie.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.59.0/http/cookie.ts";
+export * from "https://deno.land/std@0.61.0/http/cookie.ts";

--- a/vendor/https/deno.land/std/http/http_status.ts
+++ b/vendor/https/deno.land/std/http/http_status.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.59.0/http/http_status.ts";
+export * from "https://deno.land/std@0.61.0/http/http_status.ts";

--- a/vendor/https/deno.land/std/http/server.ts
+++ b/vendor/https/deno.land/std/http/server.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.59.0/http/server.ts";
+export * from "https://deno.land/std@0.61.0/http/server.ts";

--- a/vendor/https/deno.land/std/io/bufio.ts
+++ b/vendor/https/deno.land/std/io/bufio.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.59.0/io/bufio.ts";
+export * from "https://deno.land/std@0.61.0/io/bufio.ts";

--- a/vendor/https/deno.land/std/mime/multipart.ts
+++ b/vendor/https/deno.land/std/mime/multipart.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.59.0/mime/multipart.ts";
+export * from "https://deno.land/std@0.61.0/mime/multipart.ts";

--- a/vendor/https/deno.land/std/path/mod.ts
+++ b/vendor/https/deno.land/std/path/mod.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.59.0/path/mod.ts";
+export * from "https://deno.land/std@0.61.0/path/mod.ts";

--- a/vendor/https/deno.land/std/testing/asserts.ts
+++ b/vendor/https/deno.land/std/testing/asserts.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.59.0/testing/asserts.ts";
+export * from "https://deno.land/std@0.61.0/testing/asserts.ts";

--- a/vendor/https/deno.land/std/testing/bench.ts
+++ b/vendor/https/deno.land/std/testing/bench.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.59.0/testing/bench.ts";
+export * from "https://deno.land/std@0.61.0/testing/bench.ts";

--- a/vendor/https/deno.land/std/textproto/mod.ts
+++ b/vendor/https/deno.land/std/textproto/mod.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.59.0/textproto/mod.ts";
+export * from "https://deno.land/std@0.61.0/textproto/mod.ts";

--- a/vendor/https/deno.land/std/ws/mod.ts
+++ b/vendor/https/deno.land/std/ws/mod.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.59.0/ws/mod.ts";
+export * from "https://deno.land/std@0.61.0/ws/mod.ts";


### PR DESCRIPTION
Updated std version. Now all test using deno 1.2.0 pass again.
This should fix #91 . Although I'm not sure if any other issues may occur now