### PR TITLE
Session improvements

### DIFF
--- a/docs/session.md
+++ b/docs/session.md
@@ -16,7 +16,7 @@ app.use(session());
 
 ```ts
 export const DefaultSessionConfig: SessionConfig = {
-    name: "abc.session",
+    key: "abc.session",
     skipper: DefaultSkipper,
 };
 ```

--- a/docs/session.md
+++ b/docs/session.md
@@ -17,5 +17,6 @@ app.use(session());
 ```ts
 export const DefaultSessionConfig: SessionConfig = {
     name: "abc.session",
+    skipper: DefaultSkipper,
 };
 ```

--- a/docs/table_of_contents.md
+++ b/docs/table_of_contents.md
@@ -11,5 +11,6 @@
 
 - [Logger](./logger.md)
 - [CORS](./cors.md)
+- [Session](./session.md)
 
 [Style Guide](./style_guide.md)

--- a/middleware/session.ts
+++ b/middleware/session.ts
@@ -37,37 +37,37 @@ export function session(
 }
 
 export class Session {
-  private store: SessionMemoryStore;
-  public sessionID: string;
+  #store: SessionMemoryStore;
+  sessionID: string;
 
   constructor(store: SessionMemoryStore, sessionID?: string) {
-    this.store = store;
+    this.#store = store;
     this.sessionID = sessionID ? sessionID : Session.generateID();
   }
 
-  public init() {
-    if (!this.store.sessionExists(this.sessionID)) {
-      this.store.createSession(this.sessionID);
+  init() {
+    if (!this.#store.sessionExists(this.sessionID)) {
+      this.#store.createSession(this.sessionID);
     }
   }
 
-  public get(key: string): any {
-    return this.store.getValue(this.sessionID, key);
+  get(key: string): any {
+    return this.#store.getValue(this.sessionID, key);
   }
 
-  public all(): SessionData | undefined {
-    return this.store.getSession(this.sessionID);
+  all(): SessionData | undefined {
+    return this.#store.getSession(this.sessionID);
   }
 
-  public set(key: string, value: any) {
-    this.store.setValue(this.sessionID, key, value);
+  set(key: string, value: any) {
+    this.#store.setValue(this.sessionID, key, value);
   }
 
-  public destroy() {
-    this.store.deleteSession(this.sessionID);
+  destroy() {
+    this.#store.deleteSession(this.sessionID);
   }
 
-  public reset() {
+  reset() {
     this.destroy();
     this.init();
   }
@@ -83,38 +83,38 @@ export class Session {
 }
 
 export class SessionMemoryStore {
-  private sessions: Sessions = {};
+  #sessions: Sessions = {};
 
-  public sessionExists(sessionID: string): boolean {
-    return Object.keys(this.sessions).includes(sessionID);
+  sessionExists(sessionID: string): boolean {
+    return Object.keys(this.#sessions).includes(sessionID);
   }
 
-  public getSession(sessionID: string): SessionData | undefined {
+  getSession(sessionID: string): SessionData | undefined {
     if (this.sessionExists(sessionID)) {
-      return this.sessions[sessionID];
+      return this.#sessions[sessionID];
     }
     return undefined;
   }
 
-  public createSession(sessionID: string) {
-    this.sessions[sessionID] = {};
+  createSession(sessionID: string) {
+    this.#sessions[sessionID] = {};
   }
 
-  public deleteSession(sessionID: string) {
+  deleteSession(sessionID: string) {
     if (this.sessionExists(sessionID)) {
-      delete this.sessions[sessionID];
+      delete this.#sessions[sessionID];
     }
   }
 
-  public setValue(sessionID: string, key: string, value: any) {
+  setValue(sessionID: string, key: string, value: any) {
     if (this.sessionExists(sessionID)) {
-      this.sessions[sessionID][key] = value;
+      this.#sessions[sessionID][key] = value;
     }
   }
 
-  public getValue(sessionID: string, key: string): any | undefined {
+  getValue(sessionID: string, key: string): any | undefined {
     if (this.sessionExists(sessionID)) {
-      return this.sessions[sessionID][key];
+      return this.#sessions[sessionID][key];
     }
     return undefined;
   }

--- a/middleware/session.ts
+++ b/middleware/session.ts
@@ -113,10 +113,5 @@ export interface SessionConfig {
   skipper?: Skipper;
 }
 
-export interface Sessions {
-  [sessionID: string]: SessionData;
-}
-
-export interface SessionData {
-  [key: string]: any;
-}
+export type SessionData = Record<string, any>;
+export type Sessions = Record<string, SessionData>

--- a/middleware/session.ts
+++ b/middleware/session.ts
@@ -80,8 +80,11 @@ export class SessionMemoryStore {
     return Object.keys(this.sessions).includes(sessionID);
   }
 
-  public getSession(sessionID: string): SessionData {
-    return this.sessions[sessionID];
+  public getSession(sessionID: string): SessionData | undefined {
+    if (this,this.sessionExists(sessionID)) {
+      return this.sessions[sessionID];
+    }
+    return undefined;
   }
 
   public createSession(sessionID: string) {
@@ -100,7 +103,7 @@ export class SessionMemoryStore {
     }
   }
 
-  public getValue(sessionID: string, key: string): any {
+  public getValue(sessionID: string, key: string): any | undefined {
     if (this.sessionExists(sessionID)) {
       return this.sessions[sessionID][key];
     }

--- a/middleware/session_test.ts
+++ b/middleware/session_test.ts
@@ -1,0 +1,23 @@
+import { Session, SessionMemoryStore } from "./session.ts";
+
+import {
+  assertEquals,
+  assert,
+} from "../vendor/https/deno.land/std/testing/asserts.ts";
+import { createMockRequest } from "../test_util.ts";
+import { Context } from "../context.ts";
+const { test } = Deno;
+
+const options = { app: undefined!, r: createMockRequest() };
+const c = new Context(options);
+const store = new SessionMemoryStore();
+
+test("middleware session", function (): void {
+  c.session = new Session(store, "sessionKey");
+  c.setCookie(
+      { name: "sessionKey", value: c.session.sessionID, path: "/" },
+  );
+  c.session.init();
+  c.session.set("key", "value");
+  assertEquals(c.session.get("key"), "value");
+});

--- a/middleware/session_test.ts
+++ b/middleware/session_test.ts
@@ -11,13 +11,28 @@ const { test } = Deno;
 const options = { app: undefined!, r: createMockRequest() };
 const c = new Context(options);
 const store = new SessionMemoryStore();
+const skey = "abc.session";
+const key = "answer";
+const value = "42";
 
 test("middleware session", function (): void {
-  c.session = new Session(store, "sessionKey");
-  c.setCookie(
-      { name: "sessionKey", value: c.session.sessionID, path: "/" },
-  );
+  c.session = new Session(store, skey);
   c.session.init();
-  c.session.set("key", "value");
-  assertEquals(c.session.get("key"), "value");
+  c.session.set(key, value);
+  assertEquals(c.session.get(key), value);
+});
+
+test("middleware session ID generator", function (): void {
+  assertEquals(c.session.sessionID, skey);
+  c.session = new Session(store);
+  c.session.init();
+  assert(c.session.sessionID.length == 64);
+});
+
+test("middleware session memory store", function (): void {
+  assert(store.sessionExists(skey));
+  assert(store.sessionExists(c.session.sessionID));
+
+  c.session.set(key, value);
+  assertEquals(store.getSession(c.session.sessionID), { [key]: value });
 });

--- a/middleware/session_test.ts
+++ b/middleware/session_test.ts
@@ -11,26 +11,26 @@ const { test } = Deno;
 const options = { app: undefined!, r: createMockRequest() };
 const c = new Context(options);
 const store = new SessionMemoryStore();
-const skey = "abc.session";
+const testSessionID = "2y315b4j5s5e535r4d0e4e4d2l5n2x1m2146672o1o2t1j4c4w445e1t3k4s4p12";
 const key = "answer";
 const value = "42";
 
 test("middleware session", function (): void {
-  c.session = new Session(store, skey);
+  c.session = new Session(store, testSessionID);
   c.session.init();
   c.session.set(key, value);
   assertEquals(c.session.get(key), value);
 });
 
 test("middleware session ID generator", function (): void {
-  assertEquals(c.session.sessionID, skey);
+  assertEquals(c.session.sessionID, testSessionID);
   c.session = new Session(store);
   c.session.init();
-  assert(c.session.sessionID.length == 64);
+  assert(/[a-z0-9]{64}/.test(c.session.sessionID));
 });
 
 test("middleware session memory store", function (): void {
-  assert(store.sessionExists(skey));
+  assert(store.sessionExists(testSessionID));
   assert(store.sessionExists(c.session.sessionID));
 
   c.session.set(key, value);

--- a/middleware/session_test.ts
+++ b/middleware/session_test.ts
@@ -2,6 +2,7 @@ import { Session, SessionMemoryStore } from "./session.ts";
 
 import {
   assertEquals,
+  assertNotEquals,
   assert,
 } from "../vendor/https/deno.land/std/testing/asserts.ts";
 import { createMockRequest } from "../test_util.ts";
@@ -11,7 +12,8 @@ const { test } = Deno;
 const options = { app: undefined!, r: createMockRequest() };
 const c = new Context(options);
 const store = new SessionMemoryStore();
-const testSessionID = "2y315b4j5s5e535r4d0e4e4d2l5n2x1m2146672o1o2t1j4c4w445e1t3k4s4p12";
+const testSessionID =
+  "2y315b4j5s5e535r4d0e4e4d2l5n2x1m2146672o1o2t1j4c4w445e1t3k4s4p12";
 const key = "answer";
 const value = "42";
 
@@ -19,10 +21,17 @@ test("middleware session", function (): void {
   c.session = new Session(store, testSessionID);
   c.session.init();
   c.session.set(key, value);
+
   assertEquals(c.session.get(key), value);
+  assertEquals(c.session.all(), { [key]: value });
+
+  const reverseValue = value.split("").reverse().join("");
+  c.session.set(key, reverseValue);
+  assertNotEquals(c.session.get(key), value);
+  assertEquals(c.session.get(key), reverseValue);
 });
 
-test("middleware session ID generator", function (): void {
+test("middleware session sessionID generator", function (): void {
   assertEquals(c.session.sessionID, testSessionID);
   c.session = new Session(store);
   c.session.init();
@@ -35,4 +44,7 @@ test("middleware session memory store", function (): void {
 
   c.session.set(key, value);
   assertEquals(store.getSession(c.session.sessionID), { [key]: value });
+
+  store.deleteSession(testSessionID);
+  assert(!store.sessionExists(testSessionID));
 });


### PR DESCRIPTION
- [x] Skipper
- [x] Tests
- [ ] Better typings
- [ ] Session field

### Better typings
I already considered this but IMO it's very useful to be able to store data of any kind/type in a session variable without being limited to some basic types.
You probably could serialize the data into JSON on the store side which would get rid of 3 `any` typings.

### Session field
Well I first thought of using a `CustomContext` for that but this would only complicate things because the user would have to instantiate the CC on every request he wants to access the session data.

~ Lars  