### PR TITLE
Implemented deno upstream updates

### DIFF
--- a/dem.json
+++ b/dem.json
@@ -21,7 +21,7 @@
     {
       "protocol": "https",
       "path": "deno.land/x/dejs",
-      "version": "master",
+      "version": "0.8.0",
       "files": [
         "/mod.ts"
       ]

--- a/vendor/https/deno.land/x/dejs/mod.ts
+++ b/vendor/https/deno.land/x/dejs/mod.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/dejs@master/mod.ts";
+export * from "https://deno.land/x/dejs@0.8.0/mod.ts";


### PR DESCRIPTION
The deno upstream update caused all @*BRANCH tags to fail.
Therefore I've fixed this by using the version number instead. Furthermore, you're using the now-deprecated 'v'-prefix in front of the version numbers sometimes.

More information:
https://deno.land/posts/registry2
https://twitter.com/deno_land/status/1290319979825561600