### PR TITLE
Upgrade std to 0.98.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: denolib/setup-deno@v2
         with:
-          deno-version: 1.9.0
+          deno-version: 1.11.0
 
       - run: deno --version
       - run: deno fmt --check

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://github.com/zhmushan/abc/workflows/ci/badge.svg?branch=master)](https://github.com/zhmushan/abc/actions)
 [![license](https://img.shields.io/github/license/zhmushan/abc.svg)](https://github.com/zhmushan/abc)
 [![tag](https://img.shields.io/badge/deno->=1.0.0-green.svg)](https://github.com/denoland/deno)
-[![tag](https://img.shields.io/badge/std-0.92.0-green.svg)](https://github.com/denoland/deno)
+[![tag](https://img.shields.io/badge/std-0.98.0-green.svg)](https://github.com/denoland/deno)
 
 #### Quick links
 

--- a/app.ts
+++ b/app.ts
@@ -23,9 +23,9 @@ export function NotImplemented(): Error {
 
 /**
  * Hello World.
- * 
+ *
  *    const app = new Application();
- * 
+ *
  *    app
  *      .get("/hello", (c) => {
  *        return "Hello, Abc!";
@@ -90,7 +90,7 @@ export class Application {
 
   /**
    * Start an HTTP server.
-   * 
+   *
    *    app.start({ port: 8080 });
    */
   start(sc: HTTPOptions): void {
@@ -104,7 +104,7 @@ export class Application {
 
   /**
    * Stop the server immediately.
-   * 
+   *
    *    await app.close();
    */
   async close(): Promise<void> {
@@ -216,10 +216,10 @@ export class Application {
     return g;
   }
 
-  /** 
+  /**
    * Register a new route with path prefix to serve static files from the provided root directory.
    * For example, a request to `/static/js/main.js` will fetch and serve `assets/js/main.js` file.
-   * 
+   *
    *    app.static("/static", "assets");
    */
   static(prefix: string, root: string, ...m: MiddlewareFunc[]): Application {
@@ -233,9 +233,9 @@ export class Application {
     return this.get(`${prefix}/*`, h, ...m);
   }
 
-  /** 
+  /**
    * Register a new route with path to serve a static file with optional route-level middleware.
-   * 
+   *
    *    app.file("/", "public/index.html");
    */
   file(path: string, filepath: string, ...m: MiddlewareFunc[]): Application {

--- a/dem.json
+++ b/dem.json
@@ -3,7 +3,7 @@
     {
       "protocol": "https",
       "path": "deno.land/std",
-      "version": "0.92.0",
+      "version": "0.98.0",
       "files": [
         "/fmt/colors.ts",
         "/http/cookie.ts",

--- a/vendor/https/deno.land/std/fmt/colors.ts
+++ b/vendor/https/deno.land/std/fmt/colors.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.92.0/fmt/colors.ts";
+export * from "https://deno.land/std@0.98.0/fmt/colors.ts";

--- a/vendor/https/deno.land/std/http/cookie.ts
+++ b/vendor/https/deno.land/std/http/cookie.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.92.0/http/cookie.ts";
+export * from "https://deno.land/std@0.98.0/http/cookie.ts";

--- a/vendor/https/deno.land/std/http/http_status.ts
+++ b/vendor/https/deno.land/std/http/http_status.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.92.0/http/http_status.ts";
+export * from "https://deno.land/std@0.98.0/http/http_status.ts";

--- a/vendor/https/deno.land/std/http/server.ts
+++ b/vendor/https/deno.land/std/http/server.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.92.0/http/server.ts";
+export * from "https://deno.land/std@0.98.0/http/server.ts";

--- a/vendor/https/deno.land/std/io/bufio.ts
+++ b/vendor/https/deno.land/std/io/bufio.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.92.0/io/bufio.ts";
+export * from "https://deno.land/std@0.98.0/io/bufio.ts";

--- a/vendor/https/deno.land/std/mime/multipart.ts
+++ b/vendor/https/deno.land/std/mime/multipart.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.92.0/mime/multipart.ts";
+export * from "https://deno.land/std@0.98.0/mime/multipart.ts";

--- a/vendor/https/deno.land/std/path/mod.ts
+++ b/vendor/https/deno.land/std/path/mod.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.92.0/path/mod.ts";
+export * from "https://deno.land/std@0.98.0/path/mod.ts";

--- a/vendor/https/deno.land/std/testing/asserts.ts
+++ b/vendor/https/deno.land/std/testing/asserts.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.92.0/testing/asserts.ts";
+export * from "https://deno.land/std@0.98.0/testing/asserts.ts";

--- a/vendor/https/deno.land/std/testing/bench.ts
+++ b/vendor/https/deno.land/std/testing/bench.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.92.0/testing/bench.ts";
+export * from "https://deno.land/std@0.98.0/testing/bench.ts";

--- a/vendor/https/deno.land/std/textproto/mod.ts
+++ b/vendor/https/deno.land/std/textproto/mod.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.92.0/textproto/mod.ts";
+export * from "https://deno.land/std@0.98.0/textproto/mod.ts";

--- a/vendor/https/deno.land/std/ws/mod.ts
+++ b/vendor/https/deno.land/std/ws/mod.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.92.0/ws/mod.ts";
+export * from "https://deno.land/std@0.98.0/ws/mod.ts";


### PR DESCRIPTION
Bump std dependencies to v0.98.0 to bring them up-to-date.
Helps to prevent BufWriter, BufReader etc errors when using abc with up-to-date deno std.

`test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (21666ms)`

P.S. Really enjoy using abc so far :)